### PR TITLE
Test for FetchData

### DIFF
--- a/sce_demo.Rmd
+++ b/sce_demo.Rmd
@@ -72,6 +72,19 @@ altExps(sce)[["ADT"]]
 assayNames(sce)
 
 assays(sce)[["logcounts"]]
+
+# Names of traditional assays change
+# "counts" is named the same in both objects
+sobj@assays$RNA@counts["GAPDH", ] |> sum() == 
+  assays(sce)[["counts"]]["GAPDH", ] |> sum()
+
+# "data" from Seurat object is converted to "logcounts"
+sobj@assays$RNA@data["GAPDH", ] |> sum() == 
+  assays(sce)[["logcounts"]]["GAPDH", ] |> sum()
+
+# "scale.data" from Seurat object is converted to "scaledata"
+sobj@assays$RNA@scale.data["GAPDH", ] |> sum() ==
+  assays(sce)[["scaledata"]]["GAPDH", ] |> sum()
 ```
 
 ## Reductions: accessed via reducedDims()

--- a/tests/testthat/test-FetchData.R
+++ b/tests/testthat/test-FetchData.R
@@ -1,0 +1,80 @@
+library(SeuratObject, quietly = TRUE, warn.conflicts = FALSE)
+library(Seurat, quietly = TRUE, warn.conflicts = FALSE)
+
+# Dependencies of SingleCellExperiment and HDF5Array
+# (these are loaded quietly to avoid messages in the testing section)
+library(MatrixGenerics, quietly = TRUE, warn.conflicts = FALSE)
+library(BiocGenerics, quietly = TRUE, warn.conflicts = FALSE)
+library(S4Vectors, quietly = TRUE, warn.conflicts = FALSE)
+library(IRanges, quietly = TRUE, warn.conflicts = FALSE)
+library(Biobase, quietly = TRUE, warn.conflicts = FALSE)
+library(SummarizedExperiment, quietly = TRUE, warn.conflicts = FALSE)
+library(Matrix, quietly = TRUE, warn.conflicts = FALSE)
+library(DelayedArray, quietly = TRUE, warn.conflicts = FALSE)
+library(rhdf5, quietly = TRUE, warn.conflicts = FALSE)
+
+library(SingleCellExperiment, quietly = TRUE, warn.conflicts = FALSE)
+library(HDF5Array, quietly = TRUE, warn.conflicts = FALSE)
+
+# Load Seurat Object
+sobj <- AML_Seurat
+
+# Load SCE Object (with DelayedArray integration)
+sce <- AML_SCE()
+
+test_that("Fetchdata.SingleCellExperiment equivalent to Seurat method", {
+  seurat_data <-
+    FetchData(
+      sobj,
+      slot = "data",
+      vars =
+        c("ab_CD117-AB",
+          "ab_CD123-AB",
+          "ab_CD11c-AB",
+          "rna_GAPDH",
+          "rna_MEIS1",
+          # Nonexistent features
+          "ab_CD900",
+          # Metadata
+          "nCount_RNA",
+          "nFeature_RNA",
+          # "Ambiguous" feature not in RNA assay
+          "CD11a-AB"
+        )
+    )
+
+  sce_data <-
+    FetchData(
+      sce,
+      slot = "logcounts",
+      vars =
+        c("AB_CD117-AB",
+          "AB_CD123-AB",
+          "AB_CD11c-AB",
+          "RNA_GAPDH",
+          "RNA_MEIS1",
+          # Nonexistent features
+          "AB_CD900",
+          # Metadata
+          "nCount_RNA",
+          "nFeature_RNA",
+          # "Ambiguous" feature not in RNA assay
+          "CD11a-AB"
+        )
+    )
+
+  # Check rowSums and colSums of data
+  expect_equal(
+    object = rowSums(sce_data),
+    expected = rowSums(seurat_data),
+    tolerance = 1e-6,
+    ignore_attr = TRUE
+  )
+
+  expect_equal(
+    object = colSums(sce_data),
+    expected = colSums(seurat_data),
+    tolerance = 1e-6,
+    ignore_attr = TRUE
+  )
+})

--- a/tests/testthat/test-feature_data.R
+++ b/tests/testthat/test-feature_data.R
@@ -1,6 +1,0 @@
-# Load SingleCellExperiment object from HDF5 storage
-sce <- AML_SCE()
-
-test_that("No errors", {
-  #expect_no_error()
-})


### PR DESCRIPTION
Created an automated test for fetchData.SingleCellExperiment. The test runs an identical FetchData call on a Seurat and a SingleCellExperiment object, and verifies that the results are equal.