### PR TITLE
Fix #71

### DIFF
--- a/R/FetchData.R
+++ b/R/FetchData.R
@@ -115,8 +115,11 @@ FetchData.SingleCellExperiment <-
               as.matrix() |>
               t()
 
-            # Add experiment key back in
-            colnames(data) <- paste0(key, "_", keyless_vars)
+            # Add experiment key back in (assuming at least one variable was
+            # found. An error will result if none are found at this point)
+            if (length(keyless_vars) >= 1){
+              colnames(data) <- paste0(key, "_", keyless_vars)
+            }
           } else if (key %in% altExpNames(object)){
             # For alternate experimnent(s)
             # Switch to SingleCellExperiment object for the alternate experiment
@@ -144,8 +147,12 @@ FetchData.SingleCellExperiment <-
               as.matrix() |>
               t()
 
-            # Add experiment key back in
-            colnames(data) <- paste0(key, "_", keyless_vars)
+            # Add experiment key back in (assuming at least one variable was
+            # found. An error will result if none are found at this point)
+            if (length(keyless_vars) >= 1){
+              colnames(data) <- paste0(key, "_", keyless_vars)
+            }
+
           } else if (key %in% reducedDimNames(object)){
             # For reductions
             # keyless_vars will be equal to the indices of the dimensions to


### PR DESCRIPTION
The issue described in #71 was caused by an attempt to set the column names of a matrix with no columns, in the event that all features passed to the function do not exist in the object. This has been resolved by adding a conditional statement that checks if the length of features found is at least equal to one before setting column names.