### PR TITLE
Add Seurat license

### DIFF
--- a/LICENSE.note
+++ b/LICENSE.note
@@ -1,0 +1,3 @@
+The SCUBA package is distributed under MIT. SCUBA contains code from the Seurat package, which is also licensed under MIT. 
+
+A full copy of the license agreement for Seurat is provided at `./LICENSE_Seurat.md`.

--- a/LICENSE_Seurat.md
+++ b/LICENSE_Seurat.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2021 Seurat authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/R/get_all_cells.R
+++ b/R/get_all_cells.R
@@ -2,8 +2,7 @@
 #'
 #' Returns a character vector with all cell names in the object.
 #'
-#' @param object a single-cell object. Currently, Seurat and
-#' SingleCellExperiment objects are supported.
+#' @param object a single-cell object.
 #' @param ... Currently unused.
 #'
 #' @rdname get_all_cells


### PR DESCRIPTION
Add LICENSE.note, which mentions that code from the Seurat package is included in SCUBA. A copy of the Seurat license was also placed in the main directory.