### PR TITLE
Rename "slot" parameter of FetchData to "layer" 

### DIFF
--- a/R/FetchData.R
+++ b/R/FetchData.R
@@ -415,7 +415,7 @@ FetchData.SingleCellExperiment <-
 #' @param vars A character vector with desired features or metadata variables to
 #'   pull from the object. Any combination of entries in the genes matrix (X),
 #'   metadata (obs), or obsm matrices can be provided here. To include a feature
-#'   from layers, use the `slot` parameter. It is greatly preferred to specify
+#'   from layers, use the `layers` parameter. It is greatly preferred to specify
 #'   the matrix a variable is in with an underscore. for example, to pull the
 #'   FIS1 gene from the genes matrix (X), specify "X_FIS1" instead of "FIS1". To
 #'   pull metadata, use "obs_", and to pull data from a matrix in obsm, use the
@@ -425,9 +425,11 @@ FetchData.SingleCellExperiment <-
 #'   matrix in the object with that variable name. Variables that do not have a
 #'   valid key (X_, obs_, and a key from obj.obsm_names()) will be ignored, as
 #'   will duplicate variables.
-#' @param slot The assay (equivalent of slot in Seruat objects) to pull data
-#' from. To view the list of available assays in your object, use
-#' \code{assayNames({your object})}.
+#' @param layer The layer to pull data from. If unspecified, the feature will
+#' be pulled from the X matrix. To view a list of available layers, run
+#' \code{object$layers}. Layers will not work with alternate modalities stored
+#' in \code{obsm}, only the main modality (the modality in the X matrix of the
+#' object).
 #' @param cells A character vector of cells to include, as they are named in
 #' the object (i.e. according to colNames(object)). If \code{NULL}, data will
 #' be returned for all cells in the object.
@@ -443,7 +445,7 @@ FetchData.AnnDataR6 <-
   function(
     object,
     vars,
-    slot = NULL,
+    layer = NULL,
     cells = NULL
   ){
     library(reticulate)
@@ -464,6 +466,6 @@ FetchData.AnnDataR6 <-
       obj = object,
       fetch_vars = vars,
       cells = cells,
-      slot = slot
+      layer = layer
     )
   }

--- a/R/FetchData.R
+++ b/R/FetchData.R
@@ -7,9 +7,9 @@
 #' to pull from the object. To include features from an experiment other than
 #' the main experiment, use the name of the experiment as a prefix (i.e. AB_CD4
 #' for a feature in the experiment "AB" named "CD4".)
-#' @param slot The assay (equivalent of slot in Seruat objects) to pull data
-#' from. To view the list of available assays in your object, use
-#' \code{assayNames({your object})}.
+#' @param layer The assay (equivalent of layer in Seruat objects (slot in v4
+#' and earlier)) to pull data from. To view the list of available assays in
+#' your object, use \code{assayNames({your object})}.
 #' @param cells A character vector of cells to include, as they are named in
 #' the object (i.e. according to colNames(object)). If \code{NULL}, data will
 #' be returned for all cells in the object.
@@ -28,12 +28,12 @@ FetchData.SingleCellExperiment <-
   function(
     object,
     vars,
-    slot = NULL,
+    layer = NULL,
     cells = NULL
     ){
     # 1. Set default values
-    # Slot (assay): fill with default if null (via default_slot method)
-    slot <- slot %||% default_slot(object)
+    # Layer (assay): fill with default if null (via default_slot method)
+    layer <- layer %||% default_slot(object)
     # Cells: if NULL, use all cells in the object
     cells <- cells %||% get_all_cells(object)
 
@@ -93,14 +93,14 @@ FetchData.SingleCellExperiment <-
             # to avoid errors
             keyless_vars <- keyless_vars[keyless_vars %in% rownames(object)]
 
-            # Before pulling data, make sure the slot provided by the user
+            # Before pulling data, make sure the layer provided by the user
             # exists in the object. Throw an error if not
-            if (!slot %in% names(assays(object))){
+            if (!layer %in% names(assays(object))){
               stop(
                 "Error for vars ",
                 paste(keyless_vars, collapse = ", "),
-                ": slot ",
-                slot,
+                ": layer ",
+                layer,
                 " does not exist in the indicated experiment (",
                 mainExpName(object),
                 ")"
@@ -108,7 +108,7 @@ FetchData.SingleCellExperiment <-
               }
 
             data <-
-              assays(object)[[slot]][keyless_vars, cells, drop = FALSE] |>
+              assays(object)[[layer]][keyless_vars, cells, drop = FALSE] |>
               # Must be a matrix for feature names to properly display as names in
               # the final list
               # (begins as a DelayedArray)
@@ -127,14 +127,14 @@ FetchData.SingleCellExperiment <-
 
             keyless_vars <- keyless_vars[keyless_vars %in% rownames(alt_sce)]
 
-            # Before pulling data, make sure the slot provided by the user
+            # Before pulling data, make sure the layer provided by the user
             # exists in the object. Throw an error if not
-            if (!slot %in% names(assays(alt_sce))){
+            if (!layer %in% names(assays(alt_sce))){
               stop(
                 "Error for vars",
                 keyless_vars,
-                ": slot ",
-                slot,
+                ": layer ",
+                layer,
                 " does not exist in the indicated experiment (",
                 mainExpName(alt_sce),
                 ")"
@@ -143,7 +143,7 @@ FetchData.SingleCellExperiment <-
 
 
             data <-
-              assays(alt_sce)[[slot]][keyless_vars, cells, drop = FALSE] |>
+              assays(alt_sce)[[layer]][keyless_vars, cells, drop = FALSE] |>
               as.matrix() |>
               t()
 
@@ -206,12 +206,12 @@ FetchData.SingleCellExperiment <-
     remaining_vars <- vars[!vars %in% names(fetched_data)]
     main_exp_vars <- remaining_vars[remaining_vars %in% rownames(object)]
 
-    if (!slot %in% names(assays(object))){
+    if (!layer %in% names(assays(object))){
       stop(
         "Error for vars",
         main_exp_vars,
-        ": slot ",
-        slot,
+        ": layer ",
+        layer,
         " does not exist in the indicated experiment (",
         mainExpName(object),
         ")"
@@ -220,7 +220,7 @@ FetchData.SingleCellExperiment <-
 
     # Pull vars from main experiment
     main_exp_data <-
-      assays(object)[[slot]][main_exp_vars, cells, drop = FALSE] |>
+      assays(object)[[layer]][main_exp_vars, cells, drop = FALSE] |>
       as.matrix() |>
       t()
 
@@ -253,7 +253,7 @@ FetchData.SingleCellExperiment <-
 
         # Determine which of the missing vars are in the current key., if any
         missing_in_exp <-
-          missing_vars[missing_vars %in% rownames(assays(alt_sce)[[slot]])]
+          missing_vars[missing_vars %in% rownames(assays(alt_sce)[[layer]])]
 
         # For each variable found in this experiment, append the assay name to the
         # feature's entry in missing_in_exp (each entry is a vector)
@@ -318,12 +318,12 @@ FetchData.SingleCellExperiment <-
         # Load alternate experiment
         alt_sce <- altExps(object)[[key]]
 
-        if (!slot %in% names(assays(alt_sce))){
+        if (!layer %in% names(assays(alt_sce))){
           stop(
             "Error for var",
             var,
-            ": slot ",
-            slot,
+            ": layer ",
+            layer,
             " does not exist in the indicated experiment (",
             mainExpName(alt_sce),
             ")"
@@ -331,7 +331,7 @@ FetchData.SingleCellExperiment <-
         }
 
         data <-
-          assays(alt_sce)[[slot]][var, cells, drop = FALSE] |>
+          assays(alt_sce)[[layer]][var, cells, drop = FALSE] |>
           # Only one var will be fetched at once in this case, so data can be added
           # as a vector to the list of fetched data
           as.vector()

--- a/inst/extdata/Python/fetch_anndata.py
+++ b/inst/extdata/Python/fetch_anndata.py
@@ -30,7 +30,7 @@ def is_match(regex_search, target):
     else: 
         return False
 
-def fetch_keyed_vars(obj, target_vars, cells, slot):
+def fetch_keyed_vars(obj, target_vars, cells, layer):
     """
     Returns expression data for all variables in target_vars that are
     found in the object at obj. Expression data will be returned only 
@@ -50,8 +50,8 @@ def fetch_keyed_vars(obj, target_vars, cells, slot):
     None, data will be returned for all cells in the object. This is 
     passed down from the parent fetch_anndata function.
     
-    slot: Optional, a string specifying the layer to return data from, 
-    provided the variable in question is from the X matrix. The slot
+    layer: Optional, a string specifying the layer to return data from, 
+    provided the variable in question is from the X matrix. The layer
     argument is ignored for variables from all other locations. This is 
     passed down from the parent fetch_anndata function.
     
@@ -120,8 +120,8 @@ def fetch_keyed_vars(obj, target_vars, cells, slot):
             
             ### 2.2.1. Pull expression matrix for the current key location ####
             if key == "X":
-                # The X matrix alone supports "slot" (via layers)
-                # TODO: pull from layers when slot != None
+                # The X matrix alone supports "layer" (via layers)
+                # TODO: pull from layers when layer != None
                 matrix = obj.X
             elif key == "obs":
                 # Metadata (obs)
@@ -249,7 +249,7 @@ def remove_key(data, key, vars_modify=None):
     
     return data
 
-def fetch_anndata(obj, fetch_vars, cells=None, slot=None):
+def fetch_anndata(obj, fetch_vars, cells=None, layer=None):
     """
     Fetches the specified variables from an anndata object.
     
@@ -273,9 +273,10 @@ def fetch_anndata(obj, fetch_vars, cells=None, slot=None):
     cells: Optional, a list of cells to return data for. If left as 
     None, data will be returned for all cells in the object.
     
-    slot: Optional, a string specifying the layer to return data from, 
-    provided the variable in question is from the X matrix. The slot
-    argument is ignored for variables from all other locations.
+    layer: Optional, a string specifying the layer to return data from, 
+    provided the variable in question is from the X matrix. The layer 
+    argument is ignored for variables from all other locations, including 
+    alternate modalities.
     """
     # If target_vars was passed as a one-element vector from R, it will be
     # a string now. This must be converted to a list to avoid issues during
@@ -285,7 +286,7 @@ def fetch_anndata(obj, fetch_vars, cells=None, slot=None):
         fetch_vars = [fetch_vars]
     
     # 1. Set default values
-    # Slot (assay): if null, data will be pulled from object$X
+    # Layer (assay): if null, data will be pulled from object$X
 
     # Cells: if None (NULL), use all cells in the object
     if cells == None:
@@ -332,7 +333,7 @@ def fetch_anndata(obj, fetch_vars, cells=None, slot=None):
         obj = obj, 
         target_vars = fetch_vars,
         cells = cells, 
-        slot = slot
+        layer = layer
         )
     
     # 4. Identify location of remaining vars
@@ -509,7 +510,7 @@ def fetch_anndata(obj, fetch_vars, cells=None, slot=None):
         obj = obj, 
         target_vars = new_keyed_vars,
         cells = cells, 
-        slot = slot
+        layer = layer
         )
         
     fetched_data = pd.concat(

--- a/tests/testthat/test-FetchData.R
+++ b/tests/testthat/test-FetchData.R
@@ -2,7 +2,7 @@ test_that("Fetchdata.SingleCellExperiment, Fetchdata.SeuratObject and FetchData 
   seurat_data <-
     FetchData(
       AML_Seurat,
-      slot = "data",
+      layer = "data",
       vars =
         c("ab_CD117-AB",
           "ab_CD123-AB",
@@ -23,7 +23,7 @@ test_that("Fetchdata.SingleCellExperiment, Fetchdata.SeuratObject and FetchData 
   sce_data <-
     FetchData(
       AML_SCE(),
-      slot = "logcounts",
+      layer = "logcounts",
       vars =
         c("AB_CD117-AB",
           "AB_CD123-AB",
@@ -105,7 +105,7 @@ test_that("Fetchdata.SingleCellExperiment, Fetchdata.SeuratObject and FetchData 
   expect_error(
     FetchData(
       AML_Seurat,
-      slot = "data",
+      layer = "data",
       vars =
         # Nonexistent feature
         c("ab_CD900")
@@ -134,7 +134,7 @@ test_that("Fetchdata.SingleCellExperiment, Fetchdata.SeuratObject and FetchData 
   expect_error(
     FetchData(
       AML_Seurat,
-      slot = "data",
+      layer = "data",
       vars =
         # Nonexistent feature
         c("ab_CD900")


### PR DESCRIPTION
Resolves #34. The `slot` parameter was renamed to `layer` to retain compatability with future versions of Seurat, which will use this parameter instead. `layer` still works in `Seurat.FetchData` (maintained by Seurat) to pull data from v3 assays.