### PR TITLE
Fix error with Fetch_data for anndata objects with obsm matrices with multiple underscores

### DIFF
--- a/inst/extdata/Python/fetch_anndata.py
+++ b/inst/extdata/Python/fetch_anndata.py
@@ -67,12 +67,6 @@ def fetch_keyed_vars(obj, target_vars, cells, layer):
     # Currently supported locations: X, obs, and matrices within obsm
     key_names = ["X", "obs"] + list(obj.obsm_keys())
     
-    print("\nBegin fetch_keyed_vars")
-    print("keys")
-    print(key_names)
-    print("target vars")
-    print(target_vars)
-    
     # Construct a list of keys with the indices of vars that match each key
     keyed_var_locations = []
   
@@ -86,8 +80,6 @@ def fetch_keyed_vars(obj, target_vars, cells, layer):
         # Capture group will return the text in the var after the key and "_" 
         # (the name of the var in the matrix)
         key_regex = re.compile("^" + key + "_(.*)")
-        print("\nIteration for key {}".format(key))
-        print("Regex: {}".format(key_regex))
         
         # matches: a dictionary mapping the original keyed var to the "keyless" 
         # var produced from removing the key plus an underscore. The keyless var 
@@ -97,17 +89,10 @@ def fetch_keyed_vars(obj, target_vars, cells, layer):
         # regex search is "truthy". When a match is found, a a regex match 
         # object will be returned, which will evaluate as true in the if 
         # statement below.
-        print("Searching for the following vars")
-        print(target_vars)
         matches = {var:key_regex.search(var).groups()[0] 
             for var in target_vars 
             if key_regex.search(var)
             }
-        
-        print("matches")
-        print(matches)
-        print("matches.values")
-        print(matches.values())
         
         # For the X matrix, the user may use a key that conflicts with the names 
         # of common obsm matrices, such as "X_umap". To prevent "X_umap_1" from 
@@ -144,9 +129,6 @@ def fetch_keyed_vars(obj, target_vars, cells, layer):
         # Extract values from curated matches dictionary (keyless vars to search 
         # X/obs/obsm matrix for)
         keyless_vars = list(matches.values())
-        
-        print("keyless vars")
-        print(keyless_vars)
         
         ## 2.2. Fetch Data if vars exist in the current location ####
         if (len(keyless_vars) > 0):


### PR DESCRIPTION
When there is an object with reduction names sharing the same root (i.e. `X_mofa` and `X_mofa_umap`), and a reduction coordinate variable such as `X_mofa_umap_1` is entered, the `fetch_keyed_vars` function in `fetch_anndata.py` will search for "X_mofa_umap_1" in both the `X_mofa` and the `X_mofa_umap` matrices. `fetch_keyed_vars` will remove the "key" of the matrix from the variable name before searching, meaning it will search in `X_mofa` for "umap_1", and it will search in `X_mofa_umap` for "1". Only the latter is intended, and the error in #90 ocurrs when the former variable is being searched for.

To fix this issue, I added error handling to the `fetch_keyed_vars` function, directing it to continue searching after requesting a non-existent feature, and return no data from that matrix. This would result in data not being returned properly if a user searched for coordinates from `X_mofa` and `X_mofa_umap` concurrently, but this does not seem likely.