### PR TITLE
Correct BiocManager::install in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ if (!require("BiocManager", quietly = TRUE))
     install.packages("BiocManager")
 
 # Set dependencies to FALSE if you do not plan to use anndata objects
-BiocManager::install("username/pkgRepo", dependencies = TRUE)
+BiocManager::install("amc-heme/SCUBA", dependencies = TRUE)
 ```
 
 


### PR DESCRIPTION
Corrected BiocManager::install command in Installation section (I entered it as "username/pkgRepo" instead of "amc-heme/SCUBA").