### PR TITLE
Deprecate FetchData, add warning when a large number of features is requested

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SCUBA
 Type: Package
 Title: Common data accession for single cell object formats
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: c(
     person(
         "William", 
@@ -37,7 +37,7 @@ Authors@R: c(
         "Austin", 
         "Gillen", 
         email = "austin.gillen@cuanschutz.edu",
-        role = c("aut", "cre")
+        role = c("aut", "cre", "fnd")
         )
     )
 Description: SCUBA provides a common accession framework for multiple single cell object formats (Seurat, SingleCellExperiment, Anndata), facilitating analysis.

--- a/R/FetchData.R
+++ b/R/FetchData.R
@@ -35,6 +35,16 @@ FetchData.SingleCellExperiment <-
     cells = NULL,
     ...
     ){
+    lifecycle::deprecate_warn(
+      when = "1.1.2",
+      what = "FetchData.SingleCellExperiment()",
+      details = 
+        paste0(
+          "Please use fetch_data() instead. The FetchData method ",
+          "for SingleCellExperiment objects will be removed in 1.2.0."
+        )
+    )
+    
     # 1. Set default values
     # Layer (assay): fill with default if null (via default_layer method)
     layer <- layer %||% default_layer(object)
@@ -456,6 +466,15 @@ FetchData.AnnDataR6 <-
     cells = NULL,
     ...
   ){
+    lifecycle::deprecate_warn(
+      when = "1.1.2",
+      what = "FetchData.AnnDataR6()",
+      details = 
+        paste0(
+          "Please use fetch_data() instead. The FetchData method ",
+          "for anndata objects will be removed in 1.2.0."
+        )
+    )
     
     if (!requireNamespace("reticulate", quietly = TRUE)) {
       stop(

--- a/R/FetchData.R
+++ b/R/FetchData.R
@@ -41,7 +41,7 @@ FetchData.SingleCellExperiment <-
       details = 
         paste0(
           "Please use fetch_data() instead. The FetchData method ",
-          "for SingleCellExperiment objects will be removed in 1.2.0."
+          "for SingleCellExperiment objects will be removed in 1.3.0."
         )
     )
     
@@ -472,7 +472,7 @@ FetchData.AnnDataR6 <-
       details = 
         paste0(
           "Please use fetch_data() instead. The FetchData method ",
-          "for anndata objects will be removed in 1.2.0."
+          "for anndata objects will be removed in 1.3.0."
         )
     )
     

--- a/R/fetch_data.R
+++ b/R/fetch_data.R
@@ -91,6 +91,22 @@ fetch_data.Seurat <-
     slot = NULL,
     ...
   ){
+    # Check vars input
+    # If more than 1000 features are requested, warn the user of potential 
+    # performance issues
+    if (!is.null(vars)){
+      if (length(vars) >= 1000){
+        warning(
+          paste0(
+            "A very large number of features was requested (", 
+            length(vars), 
+            " features). Performance issues may be observed as a result."
+            ),
+          immediate. = TRUE
+        )
+      }
+    }
+    
     # This is a wrapper for SeuratObject::FetchData
     if (!is.null(slot)){
       # For backwards compatability with Seruat v4 and earlier, use `slot` 
@@ -126,6 +142,20 @@ fetch_data.SingleCellExperiment <-
     cells = NULL,
     ...
   ){
+    # Check vars input
+    # If more than 1000 features are requested, warn the user of potential 
+    # performance issues
+    if (length(vars) >= 1000){
+      warning(
+        paste0(
+          "A very large number of features was requested (", 
+          length(vars), 
+          " features). Performance issues may be observed as a result."
+        ),
+        immediate. = TRUE
+      )
+    }
+    
     # 1. Set default values
     # Layer (assay): fill with default if null (via default_layer method)
     layer <- layer %||% default_layer(object)
@@ -292,7 +322,8 @@ fetch_data.SingleCellExperiment <-
         '\nOnly the metadata will be returned. To get feature data from the main experiment, please add the "key" of the main experiment to the feature (eg. ',
         paste0(mainExpName(object), "_", ambiguous_meta_vars[1]),
         ")",
-        call. = FALSE
+        call. = FALSE,
+        immediate. = TRUE
       )
     }
     
@@ -520,6 +551,20 @@ fetch_data.AnnDataR6 <-
           'function with anndata objects.'
           ),
         call. = FALSE
+      )
+    }
+    
+    # Check vars input
+    # If more than 1000 features are requested, warn the user of potential 
+    # performance issues
+    if (length(vars) >= 1000){
+      warning(
+        paste0(
+          "A very large number of features was requested (", 
+          length(vars), 
+          " features). Performance issues may be observed as a result."
+        ),
+        immediate. = TRUE
       )
     }
     

--- a/man/SCUBA-package.Rd
+++ b/man/SCUBA-package.Rd
@@ -16,7 +16,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Austin Gillen \email{austin.gillen@cuanschutz.edu}
+\strong{Maintainer}: Austin Gillen \email{austin.gillen@cuanschutz.edu} [funder]
 
 Authors:
 \itemize{


### PR DESCRIPTION
- Added a warning to fetch_data when 1000 or more features are requested.
- Deprecated pascal case FetchData methods in favor of fetch_data (#118). 