### PR TITLE
Guard reticulate/anndata calls behind requireNamespace checks

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -94,6 +94,13 @@ AML_SCE <- function() {
 #' # Summary of metadata variables in object
 #' meta_varnames(AML_h5ad())
 AML_h5ad <- function() {
+  if (!requireNamespace("anndata", quietly = TRUE)) {
+    stop(
+      'Package "anndata" must be installed to use this function. ',
+      'Install it with: install.packages("anndata")',
+      call. = FALSE
+    )
+  }
   anndata::read_h5ad(
     system.file("extdata", "AML_h5ad.h5ad", package = "SCUBA")
   )
@@ -103,6 +110,13 @@ AML_h5ad <- function() {
 #' @usage AML_h5ad_backed()
 #' @export
 AML_h5ad_backed <- function() {
+  if (!requireNamespace("anndata", quietly = TRUE)) {
+    stop(
+      'Package "anndata" must be installed to use this function. ',
+      'Install it with: install.packages("anndata")',
+      call. = FALSE
+    )
+  }
   anndata::read_h5ad(
     system.file("extdata", "AML_h5ad.h5ad", package = "SCUBA"),
     backed = "r"

--- a/R/fetch_data.R
+++ b/R/fetch_data.R
@@ -696,14 +696,11 @@ fetch_data.AnnDataR6 <-
     cells = NULL,
     ...
   ) {
-    library(reticulate)
-
     if (!requireNamespace("reticulate", quietly = TRUE)) {
       stop(
-        paste0(
-          'Package "reticulate" must be installed to use this ',
-          'function with anndata objects.'
-        ),
+        'Package "reticulate" must be installed to use this ',
+        'function with anndata objects. ',
+        'Install it with: install.packages("reticulate")',
         call. = FALSE
       )
     }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,9 +4,24 @@
   # functionality (AnnData objects) will fail with an informative error at
   # call time when reticulate or anndata are absent.
   if (requireNamespace("reticulate", quietly = TRUE)) {
-    reticulate::py_require("anndata>=0.11.4")
-    reticulate::py_require("pandas>=2.0.0")
-    reticulate::py_require("numpy")
-    reticulate::py_require("scipy>=1.14.0")
+    tryCatch(
+      {
+        reticulate::py_require("anndata>=0.11.4")
+        reticulate::py_require("pandas>=2.0.0")
+        reticulate::py_require("numpy")
+        reticulate::py_require("scipy>=1.14.0")
+      },
+      error = function(e) {
+        warning(
+          paste(
+            "Optional Python dependencies for AnnData support could not be",
+            "configured during package load. AnnData functionality may be",
+            "unavailable until the Python environment is set up.",
+            conditionMessage(e)
+          ),
+          call. = FALSE
+        )
+      }
+    )
   }
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,9 +1,12 @@
 .onLoad <- function(libname, pkgname) {
-  # Establish Python package dependencies
-  # Reticulate will automatically manage a Python environment with these
-  # packages, installing each if they are not already present
-  reticulate::py_require("anndata>=0.11.4")
-  reticulate::py_require("pandas>=2.0.0")
-  reticulate::py_require("numpy")
-  reticulate::py_require("scipy>=1.14.0")
+  # Establish Python package dependencies only when reticulate is available.
+  # reticulate is in Suggests, so it may not be installed. Python-backed
+  # functionality (AnnData objects) will fail with an informative error at
+  # call time when reticulate or anndata are absent.
+  if (requireNamespace("reticulate", quietly = TRUE)) {
+    reticulate::py_require("anndata>=0.11.4")
+    reticulate::py_require("pandas>=2.0.0")
+    reticulate::py_require("numpy")
+    reticulate::py_require("scipy>=1.14.0")
+  }
 }

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -1,0 +1,23 @@
+test_that("AML_h5ad() errors informatively when anndata is not installed", {
+  local_mocked_bindings(
+    requireNamespace = function(pkg, ...) FALSE,
+    .package = "SCUBA"
+  )
+  expect_error(
+    AML_h5ad(),
+    regexp = 'Package "anndata" must be installed to use this function\\. Install it with: install\\.packages\\("anndata"\\)',
+    fixed = FALSE
+  )
+})
+
+test_that("AML_h5ad_backed() errors informatively when anndata is not installed", {
+  local_mocked_bindings(
+    requireNamespace = function(pkg, ...) FALSE,
+    .package = "SCUBA"
+  )
+  expect_error(
+    AML_h5ad_backed(),
+    regexp = 'Package "anndata" must be installed to use this function\\. Install it with: install\\.packages\\("anndata"\\)',
+    fixed = FALSE
+  )
+})

--- a/tests/testthat/test-fetch_data.R
+++ b/tests/testthat/test-fetch_data.R
@@ -548,3 +548,19 @@ test_that("fetch_data returns an error when a nonsensical feature is entered", {
     )
   )
 })
+
+test_that("fetch_data.AnnDataR6 errors informatively when reticulate is not installed", {
+  # Create a minimal mock AnnDataR6 object
+  mock_anndata <- structure(list(), class = "AnnDataR6")
+  
+  local_mocked_bindings(
+    requireNamespace = function(pkg, ...) FALSE,
+    .package = "SCUBA"
+  )
+  
+  expect_error(
+    fetch_data(mock_anndata, vars = "test_feature"),
+    regexp = 'Package "reticulate" must be installed to use this function with anndata objects\\. Install it with: install\\.packages\\("reticulate"\\)',
+    fixed = FALSE
+  )
+})


### PR DESCRIPTION
Both packages are in Suggests and must be truly optional:
- zzz.R: wrap py_require calls so .onLoad does not fail when reticulate is absent
- data.R: add requireNamespace("anndata") guard with informative stop() in AML_h5ad() and AML_h5ad_backed()
- fetch_data.R: remove bare library(reticulate) that preceded and negated the existing requireNamespace guard; improve stop() message to include install instructions